### PR TITLE
Add new type BasisInfo

### DIFF
--- a/src/FEMBasis.jl
+++ b/src/FEMBasis.jl
@@ -35,5 +35,6 @@ export NSolid
 include("math.jl")
 export interpolate, interpolate!
 export grad, grad!
+export BasisInfo
 
 end

--- a/test/test_math.jl
+++ b/test/test_math.jl
@@ -50,3 +50,19 @@ end
     dudX_expected(X) = [X[2]+1 X[1]; 4*X[2]-1 4*X[1]]
     @test isapprox(dudX, dudX_expected([0.5, 0.5]))
 end
+
+@testset "test BasisInfo" begin
+    B = BasisInfo(Quad4)
+    X = ((0.0,0.0), (1.1,0.0), (1.0,1.0), (0.0,1.0))
+    xi = (0.0,0.0)
+    eval_basis!(B, X, xi)
+    @test isapprox(B.invJ, inv(B.J))
+    @test isapprox(B.detJ, det(B.J))
+    B = BasisInfo(Hex8)
+    X = ((0.0,0.0,0.0), (1.1,0.0,0.0), (1.0,1.0,0.0), (0.0,1.0,0.0),
+         (0.0,0.0,1.0), (1.0,0.0,1.0), (1.0,1.0,1.0), (0.0,1.0,1.0))
+    xi = (0.0,0.0,0.0)
+    eval_basis!(B, X, xi)
+    @test isapprox(B.invJ, inv(B.J))
+    @test isapprox(B.detJ, det(B.J))
+end


### PR DESCRIPTION
BasisInfo is an optimized version to calculate all necessary stuff using
basis functions, including e.g. basis, basis derivatives wrt to spatial
coordinates, Jacobian and it's inverse and determinant. Everything is
nicely packes to `BasisInfo`.