### PR TITLE
update call to Calculus.differentiate (simplify by default was disabled)

### DIFF
--- a/src/create_basis.jl
+++ b/src/create_basis.jl
@@ -93,7 +93,7 @@ function calculate_interpolation_polynomial_derivatives(basis, dim)
         deq = []
         for k=1:dim
             #println("∂($(basis[j])) / ∂$(vars[k])")
-            der = differentiate(basis[j], vars[k])
+            der = simplify(differentiate(basis[j], vars[k]))
             push!(deq, der)
         end
         push!(equations, deq)


### PR DESCRIPTION
I recently had to remove the call to `simplify` within `Calculus.differentiate` because of an issue of how `eval` is used within `simplify` (https://github.com/JuliaMath/Calculus.jl/pull/124). This PR fixes FEMBasis's tests and is compatible with both the current release and upcoming release of Calculus (although it does a bit more work on the current release than needed). Sorry for the breakage!

https://github.com/JuliaLang/METADATA.jl/pull/14781