### PR TITLE
v0.3.2 : disable precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 
 [compat]
 julia = "1"
-Calculus = "0.5"
+Calculus = "0.5.1"
 Tensors = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FEMBasis"
 uuid = "353fb843-c566-51e6-ba49-78b3e3d5ebb5"
 authors = ["Jukka Aho <ahojukka5@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/create_basis.jl
+++ b/src/create_basis.jl
@@ -1,6 +1,8 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/FEMBasis.jl/blob/master/LICENSE
 
+__precompile__(false)
+
 function get_reference_element_coordinates end
 function eval_basis! end
 function eval_dbasis! end


### PR DESCRIPTION
Precompilation gets disabled to get along with recent Julia in which precompilation is by default.
This PR will resolve https://github.com/JuliaFEM/JuliaFEM.jl/issues/257
This is a temporary workaround until someone will write better code to allow precompilation.
